### PR TITLE
make gatorlink field uneditable and post successfully

### DIFF
--- a/qipr_approver/approver/templates/approver/about_you.html
+++ b/qipr_approver/approver/templates/approver/about_you.html
@@ -9,7 +9,7 @@
     {% load form_input %}
     {% load tagbox %}
     {% load address %}
-    {% form_input form.user_name %}
+    {% form_input form.user_name True %}
     {% form_input form.first_name %}
     {% form_input form.last_name %}
     {% form_input form.title %}

--- a/qipr_approver/approver/views/aboutyou.py
+++ b/qipr_approver/approver/views/aboutyou.py
@@ -20,7 +20,8 @@ def about_you(request):
     }
     if request.method == 'POST':
         about_you_form = request.POST
-        user = User.objects.get(username=about_you_form.get('user_name'))
+        username = request.session.get(constants.SESSION_VARS['gatorlink'])
+        user = User.objects.get(username=username)
         editing_user = User.objects.get(username=utils.get_current_user_gatorlink(request.session))
 
         user_crud.update_user_from_about_you_form(user, about_you_form, editing_user)


### PR DESCRIPTION
post uses session info rather than gatorlink username field