### PR TITLE
Addressing issue #85 - Randomize order of project approval questions.

### DIFF
--- a/qipr_approver/approver/forms/question_form.py
+++ b/qipr_approver/approver/forms/question_form.py
@@ -1,5 +1,6 @@
 from approver.models import Question, Section, Response
 from approver.utils import get_related
+import random
 
 class QuestionForm():
 
@@ -22,6 +23,13 @@ class QuestionForm():
         # this is js syntax probably doesnt work in django
         self.question_list.sort(key=lambda k: k['sort_order'])
         return self.question_list
+
+    def get_random_questions(self):
+        '''Call get_sorted_questions if the questions need to be in specified order ,
+        else call get_random_questions for random order'''
+        random_list = self.question_list
+        random.shuffle(random_list)
+        return random_list
 
     def get_questions(self, section):
         question_models = Question.objects.filter(section=section)

--- a/qipr_approver/approver/views/approve.py
+++ b/qipr_approver/approver/views/approve.py
@@ -40,7 +40,8 @@ def approve(request, project_id=None):
                     return utils.dashboard_redirect_and_toast(request, 'You are not authorized to edit this project.')
                 else:
                     question_form = QuestionForm(project_id=project_id)
-                    context['sorted_questions'] = question_form.get_sorted_questions()
+                    context['sorted_questions'] = question_form.get_random_questions()
+
                     return utils.layout_render(request, context)
         else:
             return utils.dashboard_redirect_and_toast(request, 'You need to have a project.')

--- a/qipr_approver/approver/workflows/project_crud.py
+++ b/qipr_approver/approver/workflows/project_crud.py
@@ -178,21 +178,20 @@ def _calculate_similarity_score(project, member):
     Sum can be 100 to scale from zero to 100 (like a percentage)
 
     keyword - 25
-    title - 20
-    big_aim - 15
-    category - 5
+    title - 10
+    big_aim - 10
+    category - 10
     clinical area - 10
     clinical setting - 10
-    description - 10
+    description - 25
     '''
-
+    description_factor = 25
     keyword_factor = 25
-    title_factor = 20
-    big_aim_factor = 15
-    category_factor = 5
+    title_factor = 10
+    big_aim_factor = 10
+    category_factor = 10
     clinical_area_factor = 10
     clinical_setting_factor = 10
-    description_factor = 10
 
     similarity = 0.0
 


### PR DESCRIPTION
Reason : In order to prevent customers from quickly selecting the answers which would get an approval, randomize the questions so that each has to be read and thought about before being answered